### PR TITLE
[Tech|UI] Display operation execution + Refactor

### DIFF
--- a/src/libutilities.py
+++ b/src/libutilities.py
@@ -37,32 +37,34 @@ class Action:
         #Enable encryption if password is given
         if password is None:
             
-            self.process = subprocess.Popen(["idevicebackup2", "backup", folder], stdout=subprocess.PIPE)
-        
+            self.process = subprocess.Popen(["idevicebackup2", "backup", folder], stdout=subprocess.PIPE, bufsize=1, universal_newlines=True)
+
+            return self.process
+
         else:
             
             print("Checking encryption...")
             self.encrypt_process = subprocess.Popen(["idevicebackup2", "encryption", "on", password, folder])
-            self.process = subprocess.Popen(["idevicebackup2", "backup", folder], stdout=subprocess.PIPE)
+            self.encrypt_process.wait()
 
-        while(self.process.poll() == None):
-            pass
+            self.process = subprocess.Popen(["idevicebackup2", "backup", folder], stdout=subprocess.PIPE, bufsize=1, universal_newlines=True)
+
+            return self.process
 
     def restore(self, folder, password):
         
         if password is None:
             
-            self.process = subprocess.Popen(["idevicebackup2", "restore", folder], stdout=subprocess.PIPE)
-        
+            self.process = subprocess.Popen(["idevicebackup2", "restore", folder], stdout=subprocess.PIPE, bufsize=1, universal_newlines=True)
+
+            return self.process
+
         else:
 
             print("Restoring encrypted backup...")
-            self.process = subprocess.Popen(["idevicebackup2", "restore", "--password", password, folder], stdout=subprocess.PIPE)
+            self.process = subprocess.Popen(["idevicebackup2", "restore", "--password", password, folder], stdout=subprocess.PIPE, bufsize=1, universal_newlines=True)
 
-
-        while(self.process.poll() == None):
-            pass
-
+            return self.process
 
     def cancel(self):
         

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -37,7 +37,7 @@ class App(ft.UserControl):
         
         self.display_folderpath = ft.TextField(
             hint_text="Select folder icon", width=400, read_only=True, border="none", 
-            filled=True, max_lines=3
+            filled=True, max_lines=3, color="#a6a6a6"
         )
 
         self.select_folder_icon = ft.IconButton(
@@ -100,11 +100,7 @@ class App(ft.UserControl):
     #Close action finished banner
     def close_banner(self, e):
         
-        if(self.backup_cancel_banner.open):
-            self.backup_cancel_banner.open = False
-        elif(self.restore_cancel_banner.open):
-            self.restore_cancel_banner.open = False
-        elif(self.lib_not_installed_banner.open):
+        if(self.lib_not_installed_banner.open):
             self.lib_not_installed_banner.open = False
 
         self.update()

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,7 +1,8 @@
 import flet as ft
-from libutilities import scan, Action
+from libutilities import scan
 from ui.about import About
 from ui.encrypt import Encrypt
+from ui.operations import Operation
 
 class App(ft.UserControl): 
     
@@ -13,46 +14,9 @@ class App(ft.UserControl):
 
         #Import encryption password container row
         self.pwd_encrypt = Encrypt()
-        
-        #Action (operations - backup, restore and cancel) obj to used later
-        self.action = Action()
-        
 
-        #Action (pop-up) dialogs
-        self.backup_dialog = ft.AlertDialog(
-            title=ft.Text("Backing Up Device", text_align="center"), 
-            content=ft.Column(
-                [ft.Text("This will take some time"), ft.ProgressRing()],
-                height=50, horizontal_alignment="center"
-            ),
-            actions=[ft.TextButton("Cancel", on_click=self.cancel_op)],
-            content_padding=40, modal=True
-        )
-
-        self.restore_dialog = ft.AlertDialog(
-            title=ft.Text("Restoring Device", text_align="center"), 
-            content=ft.Column(
-                [ft.Text("This will take some time"), ft.ProgressRing()],
-                height=50, horizontal_alignment="center"
-            ),
-            actions=[ft.TextButton("Cancel", on_click=self.cancel_op)],
-            content_padding=40, modal=True
-        )
-
-        #Check if operation is cancelled
-        self.cancel_pressed = None
-
-        self.lib_output = ft.TextField(max_lines=6, height=200, filled=True, read_only=True)
-        self.result_dialog = ft.AlertDialog(
-            content=ft.Column(
-                [
-                    ft.Text("Scroll down to view the output", text_align="center", size=16, style="bodySmall"),
-                    self.lib_output, 
-                    ft.Text("Click anywhere outside the dialog to close", text_align="center", size=16, style="bodySmall")
-                ],
-                height=220, width=400, horizontal_alignment="center"
-            ), content_padding=40
-        )
+        #Process dialog for Action
+        self.operation_dialog = Operation()
 
 
         #Snackbar (bottom) dialog
@@ -62,16 +26,6 @@ class App(ft.UserControl):
         
 
         #Banner dialog
-        self.backup_cancel_banner = ft.Banner(
-            content=ft.Text("Backup cancelled"),
-            actions=[ft.TextButton("Ok", on_click=self.close_banner)]
-        )
-        
-        self.restore_cancel_banner = ft.Banner(
-            content=ft.Text("Backup cancelled"),
-            actions=[ft.TextButton("Ok", on_click=self.close_banner)]
-        )
-
         self.lib_not_installed_banner = ft.Banner(
             content=ft.Text("Looks like libimobiledevice or libimobiledevice-utils is not installed"),
             actions=[ft.TextButton("Ok", on_click=self.close_banner)]
@@ -119,13 +73,12 @@ class App(ft.UserControl):
         self.main_container = ft.Stack(
             [
                 #Alerts and dialogs go here
-                self.backup_cancel_banner, self.backup_dialog, self.restore_dialog, self.lib_not_installed_banner, 
-                self.no_device_dialog, self.no_folder_selected_dlg, self.restore_cancel_banner, self.result_dialog,
+                self.lib_not_installed_banner, self.operation_dialog,
+                self.no_device_dialog, self.no_folder_selected_dlg,
 
                 #Others
                 ft.Column(
-                    [self.folder_container, self.pwd_encrypt, self.options_container, 
-                    self.about_button], 
+                    [self.folder_container, self.pwd_encrypt, self.options_container, self.about_button], 
                     spacing=30, horizontal_alignment="center"
                 )
             ]
@@ -175,40 +128,10 @@ class App(ft.UserControl):
         if lib_installed and status:
             print("Device found!")
 
-            #Set this to off
-            self.cancel_pressed = False
-            
-            #Display backup alert progress dialog
-            self.backup_dialog.open = True
-            self.update()
-
             #Run backup operation
             print("Backup running...")
             pwd = self.pwd_encrypt.get_pwd()#Check if password is given
-            self.action.backup(self.display_folderpath.value, pwd)
-
-            #Store output text
-            self.poutput = self.action.process.communicate()
-            self.lib_output.value = self.poutput[0].decode()
-
-            #Successfully executed with return code as 0
-            if self.action.process.poll() == 0:
-                self.backup_dialog.open = False 
-                
-                self.result_dialog.title = ft.Text("Backup Successful", text_align="center")
-                self.result_dialog.open = True
-
-                print("Backup successfully finished")
-
-                self.update()
-            else:
-                if not self.cancel_pressed:
-                    self.backup_dialog.open = False 
-                    
-                    self.result_dialog.title = ft.Text("Backup Unsuccessful", text_align="center")
-                    self.result_dialog.open = True
-
-                    print("Something went wrong")
+            self.operation_dialog.backup(self.display_folderpath.value, pwd)
 
         elif lib_installed and not status:
             self.no_device_dialog.open = True
@@ -237,42 +160,11 @@ class App(ft.UserControl):
         if lib_installed and status:
             print("Device found!")
 
-            #Set this to off
-            self.cancel_pressed = False
-            
-            #Display backup alert progress dialog
-            self.restore_dialog.open = True
-            self.update()
-
             #Run restore operation
             print("Restore running...")
             pwd = self.pwd_encrypt.get_pwd()#Check if password is given
-            self.action.restore(self.display_folderpath.value, pwd)
+            self.operation_dialog.restore(self.display_folderpath.value, pwd)
 
-            #Store output text
-            self.poutput = self.action.process.communicate()
-            self.lib_output.value = self.poutput[0].decode()
-
-            #Successfully executed with return code as 0
-            if self.action.process.poll() == 0:
-                self.restore_dialog.open = False
-
-                self.result_dialog.title = ft.Text("Restore Successful", text_align="center")
-                self.result_dialog.open = True
-
-                print("Restore successfully finished")
-
-                self.update()
-            else:
-                if not self.cancel_pressed:
-                    self.restore_dialog.open = False
-                    
-                    self.result_dialog.title = ft.Text("Restore Unsuccessful", text_align="center")
-                    self.result_dialog.open = True
-
-                    print("Something went wrong")
-
-                    self.update()
         elif lib_installed and not status:
             self.no_device_dialog.open = True
             self.update()
@@ -281,31 +173,4 @@ class App(ft.UserControl):
             self.lib_not_installed_banner.open = True
 
             self.update()        
-
-
-    def cancel_op(self, e):
-        
-        self.action.cancel()
-
-        #close alert dialogs
-        if(self.backup_dialog.open):
-            
-            self.backup_dialog.open = False
-
-            self.backup_cancel_banner.open = True
-
-            print("Backup cancelled")
-
-        elif(self.restore_dialog.open):
-            
-            self.restore_dialog.open = False
-
-            self.restore_cancel_banner.open = True
-
-            print("Restore cancelled")
-
-        #Set this to True
-        self.cancel_pressed = True
-
-        self.update()
 

--- a/src/ui/operations.py
+++ b/src/ui/operations.py
@@ -1,0 +1,96 @@
+import flet as ft
+from libutilities import Action
+
+class Operation(ft.UserControl):
+    
+    def build(self):
+        
+        self.action = Action()
+        
+        self.lib_output = ft.TextField(value="", filled=True, read_only=True, multiline=True, text_size=13)
+        
+        self.close_button = ft.TextButton("Close", disabled=True, on_click=self.close_dialog)
+        self.cancel_button = ft.TextButton("Cancel", disabled=False, on_click=self.cancel_op)
+
+        self.loading = ft.ProgressBar()
+        
+        self.result_dialog = ft.AlertDialog(
+            content=ft.Column(
+                [
+                    self.loading,
+                    ft.Column(
+                        [self.lib_output], 
+                        horizontal_alignment="center", expand=True, auto_scroll=True, scroll="auto",
+                        width=300, height=300
+                    ),
+                ]
+            ), 
+            content_padding=30, modal=True,
+            actions=[self.close_button, self.cancel_button]
+        )
+
+        return self.result_dialog
+
+    def backup(self, folder, pwd):
+
+        self.result_dialog.open = True
+        self.result_dialog.title = ft.Text("Backing Up", text_align="center")
+        self.update()
+
+        process = self.action.backup(folder, pwd)
+
+        for line in process.stdout:
+            print(line, end="")
+            self.lib_output.value += line
+            self.update()
+
+        process.wait()
+
+        self.close_button.disabled = False
+        self.cancel_button.disabled = True
+        self.loading.value = 0.0
+        self.update()
+
+    
+    def restore(self, folder, pwd):
+
+        self.result_dialog.open = True
+        self.result_dialog.title = ft.Text("Restoring", text_align="center")
+        self.update()
+
+        process = self.action.restore(folder, pwd)
+
+        for line in process.stdout:
+            print(line)
+            self.lib_output.value += line
+            self.update()
+
+        process.wait()
+
+        self.close_button.disabled = False
+        self.cancel_button.disabled = True
+        self.loading.value = 0.0
+        self.update()
+
+
+    def close_dialog(self, e):
+
+        #Reset properties to default
+        self.lib_output.value = ""
+        self.close_button.disabled = True
+        self.cancel_button.disabled = False
+        self.loading.value = None
+        self.result_dialog.open = False
+        self.update()
+
+
+    def cancel_op(self, e):
+
+        self.lib_output.value += "\n--CANCELLED BY USER--"
+        self.loading.value = 0.0
+        self.update()
+
+        self.action.cancel()
+
+        
+

--- a/src/ui/operations.py
+++ b/src/ui/operations.py
@@ -7,7 +7,7 @@ class Operation(ft.UserControl):
         
         self.action = Action()
         
-        self.lib_output = ft.TextField(value="", filled=True, read_only=True, multiline=True, text_size=13)
+        self.lib_output = ft.TextField(value="", filled=True, read_only=True, multiline=True, text_size=13, color=ft.colors.AMBER)
         
         self.close_button = ft.TextButton("Close", disabled=True, on_click=self.close_dialog)
         self.cancel_button = ft.TextButton("Cancel", disabled=False, on_click=self.cancel_op)
@@ -21,10 +21,10 @@ class Operation(ft.UserControl):
                     ft.Column(
                         [self.lib_output], 
                         horizontal_alignment="center", expand=True, auto_scroll=True, scroll="auto",
-                        width=300, height=300
+                        width=400
                     ),
-                ]
-            ), 
+                ], width=400
+            ),
             content_padding=30, modal=True,
             actions=[self.close_button, self.cancel_button]
         )
@@ -35,6 +35,7 @@ class Operation(ft.UserControl):
 
         self.result_dialog.open = True
         self.result_dialog.title = ft.Text("Backing Up", text_align="center")
+        self.lib_output.value = "...\n"
         self.update()
 
         process = self.action.backup(folder, pwd)
@@ -56,12 +57,13 @@ class Operation(ft.UserControl):
 
         self.result_dialog.open = True
         self.result_dialog.title = ft.Text("Restoring", text_align="center")
+        self.lib_output.value = "...\n"
         self.update()
 
         process = self.action.restore(folder, pwd)
 
         for line in process.stdout:
-            print(line)
+            print(line, end="")
             self.lib_output.value += line
             self.update()
 


### PR DESCRIPTION
- A new dialog that displays the process output while it's executing with auto-scrolling.
- Added a progress bar for above dialog
- Removed the old action backup,restore and result dialogs
- Removed banner/restore cancel banner
- Refactor how process is handled and read
- Add colour to folder path text (`#a6a6a6`) and process dialog output (`#AMBER`)